### PR TITLE
Require stable weekly restore signal

### DIFF
--- a/Sources/CodexRadarCore/NotificationPolicy.swift
+++ b/Sources/CodexRadarCore/NotificationPolicy.swift
@@ -36,6 +36,7 @@ public struct NotificationMemory: Equatable {
     public var lastWeeklyRestoreKey: String?
     public var lastWeeklyWarningAt: Date?
     public var lastWeeklyCriticalAt: Date?
+    public var pendingWeeklyRestoreKey: String?
 
     public init(
         initialized: Bool = false,
@@ -47,7 +48,8 @@ public struct NotificationMemory: Equatable {
         lastWeeklyCriticalKey: String? = nil,
         lastWeeklyRestoreKey: String? = nil,
         lastWeeklyWarningAt: Date? = nil,
-        lastWeeklyCriticalAt: Date? = nil
+        lastWeeklyCriticalAt: Date? = nil,
+        pendingWeeklyRestoreKey: String? = nil
     ) {
         self.initialized = initialized
         self.lastSpeedOpenKey = lastSpeedOpenKey
@@ -59,6 +61,7 @@ public struct NotificationMemory: Equatable {
         self.lastWeeklyRestoreKey = lastWeeklyRestoreKey
         self.lastWeeklyWarningAt = lastWeeklyWarningAt
         self.lastWeeklyCriticalAt = lastWeeklyCriticalAt
+        self.pendingWeeklyRestoreKey = pendingWeeklyRestoreKey
     }
 }
 
@@ -213,17 +216,45 @@ public struct NotificationPolicy {
             }
         }
 
+        let currentReset = current.rateLimits?.weeklyBucket?.resetsAt
+        let restoreKey = currentReset.map { "\($0):restored" }
+        if let pendingKey = memory.pendingWeeklyRestoreKey {
+            if let restoreKey,
+               pendingKey == restoreKey,
+               remaining >= AppConstants.restoredRemainingPercent {
+                memory.pendingWeeklyRestoreKey = nil
+                appendWeeklyRestoreEvent(
+                    key: pendingKey,
+                    remaining: remaining,
+                    memory: &memory,
+                    events: &events
+                )
+                return
+            }
+            if pendingKey != restoreKey || remaining < AppConstants.restoredRemainingPercent {
+                memory.pendingWeeklyRestoreKey = nil
+            }
+        }
+
         guard let previousRemaining = previous?.rateLimits?.weeklyRemainingPercent else {
             return
         }
         let previousReset = previous?.rateLimits?.weeklyBucket?.resetsAt
-        let currentReset = current.rateLimits?.weeklyBucket?.resetsAt
         guard previousRemaining <= AppConstants.warningRemainingPercent,
               remaining >= AppConstants.restoredRemainingPercent,
-              previousReset != currentReset else {
+              previousReset != currentReset,
+              let restoreKey else {
             return
         }
-        let key = "\(resetKey):restored"
+        memory.pendingWeeklyRestoreKey = restoreKey
+    }
+
+    private func appendWeeklyRestoreEvent(
+        key: String,
+        remaining: Int,
+        memory: inout NotificationMemory,
+        events: inout [NotificationEvent]
+    ) {
         guard memory.lastWeeklyRestoreKey != key else {
             return
         }

--- a/Sources/CodexRadarSentinel/SentinelStore.swift
+++ b/Sources/CodexRadarSentinel/SentinelStore.swift
@@ -1264,6 +1264,7 @@ private struct PersistedNotificationMemory: Codable {
     let lastWeeklyRestoreKey: String?
     let lastWeeklyWarningAt: Date?
     let lastWeeklyCriticalAt: Date?
+    let pendingWeeklyRestoreKey: String?
 
     init(value: NotificationMemory) {
         self.initialized = value.initialized
@@ -1276,6 +1277,7 @@ private struct PersistedNotificationMemory: Codable {
         self.lastWeeklyRestoreKey = value.lastWeeklyRestoreKey
         self.lastWeeklyWarningAt = value.lastWeeklyWarningAt
         self.lastWeeklyCriticalAt = value.lastWeeklyCriticalAt
+        self.pendingWeeklyRestoreKey = value.pendingWeeklyRestoreKey
     }
 
     var value: NotificationMemory {
@@ -1289,7 +1291,8 @@ private struct PersistedNotificationMemory: Codable {
             lastWeeklyCriticalKey: lastWeeklyCriticalKey,
             lastWeeklyRestoreKey: lastWeeklyRestoreKey,
             lastWeeklyWarningAt: lastWeeklyWarningAt,
-            lastWeeklyCriticalAt: lastWeeklyCriticalAt
+            lastWeeklyCriticalAt: lastWeeklyCriticalAt,
+            pendingWeeklyRestoreKey: pendingWeeklyRestoreKey
         )
     }
 }

--- a/Tests/CodexRadarCoreTests/NotificationPolicyTests.swift
+++ b/Tests/CodexRadarCoreTests/NotificationPolicyTests.swift
@@ -88,6 +88,63 @@ final class NotificationPolicyTests: XCTestCase {
         XCTAssertEqual(third.map(\.title), ["Codex 周额度偏低"])
     }
 
+    func testWeeklyRestoreRequiresStableConfirmation() throws {
+        var memory = NotificationMemory(initialized: true)
+        let lowState = DashboardState(
+            rateLimits: try sampleDashboard(weeklyUsed: 86, weeklyResetsAt: 1_781_140_743),
+            current: nil,
+            prediction: nil,
+            modelIQ: nil
+        )
+        let restoredState = DashboardState(
+            rateLimits: try sampleDashboard(weeklyUsed: 0, weeklyResetsAt: 1_784_084_696),
+            current: nil,
+            prediction: nil,
+            modelIQ: nil
+        )
+
+        let first = NotificationPolicy().evaluate(previous: lowState, current: restoredState, memory: &memory)
+        XCTAssertTrue(first.isEmpty)
+        XCTAssertEqual(memory.pendingWeeklyRestoreKey, "1784084696:restored")
+        XCTAssertNil(memory.lastWeeklyRestoreKey)
+
+        let second = NotificationPolicy().evaluate(previous: restoredState, current: restoredState, memory: &memory)
+        XCTAssertEqual(second.map(\.title), ["Codex 周额度已恢复"])
+        XCTAssertEqual(memory.lastWeeklyRestoreKey, "1784084696:restored")
+        XCTAssertNil(memory.pendingWeeklyRestoreKey)
+
+        let third = NotificationPolicy().evaluate(previous: restoredState, current: restoredState, memory: &memory)
+        XCTAssertTrue(third.isEmpty)
+    }
+
+    func testWeeklyRestoreCandidateClearsWhenResetReverts() throws {
+        var memory = NotificationMemory(
+            initialized: true,
+            lastWeeklyWarningKey: "1781140743:warning"
+        )
+        let lowState = DashboardState(
+            rateLimits: try sampleDashboard(weeklyUsed: 76, weeklyResetsAt: 1_781_140_743),
+            current: nil,
+            prediction: nil,
+            modelIQ: nil
+        )
+        let transientRestoredState = DashboardState(
+            rateLimits: try sampleDashboard(weeklyUsed: 0, weeklyResetsAt: 1_784_084_696),
+            current: nil,
+            prediction: nil,
+            modelIQ: nil
+        )
+
+        let first = NotificationPolicy().evaluate(previous: lowState, current: transientRestoredState, memory: &memory)
+        XCTAssertTrue(first.isEmpty)
+        XCTAssertEqual(memory.pendingWeeklyRestoreKey, "1784084696:restored")
+
+        let second = NotificationPolicy().evaluate(previous: transientRestoredState, current: lowState, memory: &memory)
+        XCTAssertTrue(second.isEmpty)
+        XCTAssertNil(memory.pendingWeeklyRestoreKey)
+        XCTAssertNil(memory.lastWeeklyRestoreKey)
+    }
+
     func testRetiredCodexRadarPredictionDoesNotNotify() throws {
         var memory = NotificationMemory(initialized: true)
         let current = try JSONDecoder().decode(RadarCurrent.self, from: Data("""


### PR DESCRIPTION
## Summary

- require weekly restore notifications to survive a second matching quota poll before delivery
- persist the pending restore candidate across app refresh state saves
- cover stable restore confirmation and transient reset rollback in notification policy tests

## Root Cause

Codex app-server can briefly report a high remaining weekly quota with a new reset timestamp before reverting. Sentinel previously trusted that single sample and sent the restored notification immediately.

## Validation

- swift test
